### PR TITLE
Reduce memory usage for remote DBs

### DIFF
--- a/lib/mmdb2/reader.ex
+++ b/lib/mmdb2/reader.ex
@@ -11,7 +11,10 @@ defmodule Geolix.Adapter.MMDB2.Reader do
 
     filename = "/tmp/geolite_db"
 
-    with {:ok, :saved_to_file} <- :httpc.request(:get, {String.to_charlist(url), []}, [], [stream: String.to_charlist(filename)]),
+    with {:ok, :saved_to_file} <-
+           :httpc.request(:get, {String.to_charlist(url), []}, [],
+             stream: String.to_charlist(filename)
+           ),
          {:ok, data} <- File.read(filename) do
       result =
         data


### PR DESCRIPTION
I've tried unsuccessfully to deploy to Heroku and Render.com because of container memory limit (512 MB).

This PR fixes it by streaming data instead of holding it in memory. It might be a bug in `:httpc` as DBs are less than 100 MB, but it increases memory consumption by more than 0.5 GB, sometimes even whole GB. I've experimented with regular `:httpc.request()` and it seems to be the only cause.

With these changes I was able to deploy to Render.com Starter Plan instance (512 MB).