### PR TITLE
Change license metadata field to a valid SPDX identifier

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -103,7 +103,7 @@ defmodule Geolix.Adapter.MMDB2.MixProject do
   defp package do
     %{
       files: ["CHANGELOG.md", "LICENSE", "mix.exs", "README.md", "lib"],
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: %{"GitHub" => @url_github}
     }
   end


### PR DESCRIPTION
Not mandatory, but recommended for hex.pm. https://hex.pm/docs/publish#adding-metadata-to-code-classinlinemixexscode

Can be useful for a project like https://github.com/Cantido/hex_licenses

Related: https://github.com/elixir-geolix/geolix/pull/32